### PR TITLE
Correct how CocoaPods is written in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you want to buy the app you can find it on the [App Store][appstore].
 I you are interested in the Pure Data patch check out *monopatch.pd* in the *MonotoneDelay* folder.
 
 ### Running the App
-You need [cocoapods][cocoapods] to load external dependencies.
+You need [CocoaPods][cocoapods] to load external dependencies.
 Once you have cocoapods installed go to the project's directory and run:
 
     pod install

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I you are interested in the Pure Data patch check out *monopatch.pd* in the *Mon
 
 ### Running the App
 You need [CocoaPods][cocoapods] to load external dependencies.
-Once you have cocoapods installed go to the project's directory and run:
+Once you have CocoaPods installed go to the project's directory and run:
 
     pod install
 


### PR DESCRIPTION
See https://github.com/CocoaPods/shared_resources/tree/master/media :)

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
